### PR TITLE
MA-3750/ Create Global CloudTrail for new customers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ baseHandler.post = function(params, callback) {
   var aws_iam = new (require('aws-services-lib/aws/role.js'))();
 
   var input = {};
-  //if (params.multiRegion)  input.multiRegion = params.multiRegion;
+  if (params.multiRegion)  input.multiRegion = params.multiRegion;
   if (params.region) input['region'] = params.region;
   if (params.credentials) input['creds'] = new AWS.Credentials({
     accessKeyId: params.credentials.AccessKeyId,

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,6 @@ baseHandler.get = function(params, callback) {
     trailName: trailName
   };
   
-  if (params.multiRegion)  input.multiRegion = params.multiRegion;
   if (params.region) input['region'] = params.region;
   if (params.credentials) {
     input['creds'] = new AWS.Credentials({

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,8 @@ baseHandler.get = function(params, callback) {
   var input = {
     trailName: trailName
   };
+  
+  if (params.multiRegion)  input.multiRegion = params.multiRegion;
   if (params.region) input['region'] = params.region;
   if (params.credentials) {
     input['creds'] = new AWS.Credentials({

--- a/template.yaml
+++ b/template.yaml
@@ -72,7 +72,7 @@ Resources:
       Environment:
         Variables:
           TRAIL_NAME: "Default"
-          BUCKET_NAME_POSTFIX: ".cloudtrail"
+          BUCKET_NAME_POSTFIX: ".globalCloudtrail"
           BUCKET_POLICY_NAME: "bucket_cloudtrail_policy"
       Events:
         GetResource:

--- a/template.yaml
+++ b/template.yaml
@@ -71,7 +71,7 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          TRAIL_NAME: "Default"
+          TRAIL_NAME: "GlobalCloudTrail"
           BUCKET_NAME_POSTFIX: ".globalcloudtrail"
           BUCKET_POLICY_NAME: "bucket_cloudtrail_policy"
       Events:

--- a/template.yaml
+++ b/template.yaml
@@ -72,7 +72,7 @@ Resources:
       Environment:
         Variables:
           TRAIL_NAME: "Default"
-          BUCKET_NAME_POSTFIX: ".globalCloudtrail"
+          BUCKET_NAME_POSTFIX: ".globalcloudtrail"
           BUCKET_POLICY_NAME: "bucket_cloudtrail_policy"
       Events:
         GetResource:


### PR DESCRIPTION
Purpose : 

Currently we are enabling cloudtrail in every region for new customer in the onboarding process but now create Global CloudTrail for new customers in the onboarding state machine flow.

Changes : 

-  Modified the index file by adding multiRegion parameter.