### PR TITLE
Renamed the global cloudtrail S3 bucket to not have '.' in name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ baseHandler.post = function(params, callback) {
       var bucketNamePostfix = process.env.BUCKET_NAME_POSTFIX;
       var bucketPolicyName = process.env.BUCKET_POLICY_NAME;
 
-      var bucketName = input.accountId + bucketNamePostfix + "." + params.region;
+      var bucketName = input.accountId + bucketNamePostfix + "-" + params.region;
       var resources = [
         'arn:aws:s3:::' + bucketName,
         'arn:aws:s3:::' + bucketName + '/AWSLogs/' + input.accountId + '/*'];

--- a/template.yaml
+++ b/template.yaml
@@ -72,7 +72,7 @@ Resources:
       Environment:
         Variables:
           TRAIL_NAME: "GlobalCloudTrail"
-          BUCKET_NAME_POSTFIX: ".globalcloudtrail"
+          BUCKET_NAME_POSTFIX: "-globalcloudtrail"
           BUCKET_POLICY_NAME: "bucket_cloudtrail_policy"
       Events:
         GetResource:


### PR DESCRIPTION
Changed the global cloudTrail S3 bucket naming convention for new accounts which gets created as part of this Lambda function